### PR TITLE
Replace taglib with rust-id3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,12 +71,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "id3"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4986e42d23212d7e344e7f3b213bce889071bba3235c2766d24b0a12dec1ef6c"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "flate2",
 ]
 
 [[package]]
@@ -78,10 +126,10 @@ name = "mack"
 version = "1.1.1"
 dependencies = [
  "clap",
+ "id3",
  "lazy_static",
  "libc",
  "regex",
- "taglib",
  "walkdir",
 ]
 
@@ -90,6 +138,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "regex"
@@ -122,25 +179,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "taglib"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89f5ef37e426deffeed459ea78a564bbe85baf6a9b023a69437655b46ad2013"
-dependencies = [
- "libc",
- "taglib-sys",
-]
-
-[[package]]
-name = "taglib-sys"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e20ea22a603f1e8ccea16694cf8e8e3a192e5d6d6bb41d6e86dcbf3680d2a4e"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ walkdir = "2"
 lazy_static = "1"
 regex = "1"
 libc = "0.2"
+id3 = "1"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap = "2"
 walkdir = "2"
 lazy_static = "1"
 regex = "1"
-taglib = "1"
 libc = "0.2"
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,15 @@ extern crate walkdir;
 extern crate lazy_static;
 extern crate libc;
 extern crate regex;
-extern crate taglib;
+extern crate id3;
 
 mod extract;
 mod fixers;
 mod mtime;
 mod rename;
+#[allow(dead_code)]
+#[allow(unused_variables)]
+mod taglib;
 mod track;
 mod types;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@ extern crate clap;
 extern crate walkdir;
 #[macro_use]
 extern crate lazy_static;
+extern crate id3;
 extern crate libc;
 extern crate regex;
-extern crate id3;
 
 mod extract;
 mod fixers;

--- a/src/taglib.rs
+++ b/src/taglib.rs
@@ -4,40 +4,40 @@ use id3::{self, TagLike};
 
 /// A representation of an audio file, with meta-data and properties.
 pub struct File {
-	path: PathBuf,
+    path: PathBuf,
 }
 
 impl File {
-	/// Creates a new `taglib::File` for the given `path`.
-	pub fn new(path: &PathBuf) -> Result<File, FileError> {
-		Ok(File { path: path.clone() })
-	}
+    /// Creates a new `taglib::File` for the given `path`.
+    pub fn new(path: &PathBuf) -> Result<File, FileError> {
+        Ok(File { path: path.clone() })
+    }
 
-	/// Returns the `taglib::Tag` instance for the given file.
-	pub fn tag(&self) -> Result<Tag, FileError> {
-		if let Ok(tag) = id3::Tag::read_from_path(&self.path) {
-			Ok(Tag { tag })
-		} else {
-			Err(FileError::NoAvailableTag)
-		}
-	}
+    /// Returns the `taglib::Tag` instance for the given file.
+    pub fn tag(&self) -> Result<Tag, FileError> {
+        if let Ok(tag) = id3::Tag::read_from_path(&self.path) {
+            Ok(Tag { tag })
+        } else {
+            Err(FileError::NoAvailableTag)
+        }
+    }
 
-	/// Updates the meta-data of the file.
-	pub fn save(&self) -> bool {
-		true
-	}
+    /// Updates the meta-data of the file.
+    pub fn save(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug)]
 pub enum FileError {
-	/// The file is an invalid or an unrecognized audio container
-	InvalidFile,
-	/// The file name is invalid
-	InvalidFileName,
-	/// No meta-data is available
-	NoAvailableTag,
-	/// No audio properties are available
-	NoAvailableAudioProperties,
+    /// The file is an invalid or an unrecognized audio container
+    InvalidFile,
+    /// The file name is invalid
+    InvalidFileName,
+    /// No meta-data is available
+    NoAvailableTag,
+    /// No audio properties are available
+    NoAvailableAudioProperties,
 }
 
 /// The abstract meta-data container for audio files
@@ -46,58 +46,57 @@ pub enum FileError {
 /// method.
 #[allow(dead_code)]
 pub struct Tag {
-	tag: id3::Tag,
+    tag: id3::Tag,
 }
 
 impl Tag {
-	/// Returns the track name, or an empty string if no track name is present.
-	pub fn title(&self) -> Option<String> {
-		self.tag.title().and_then(|x| Some(x.to_string()))
-	}
+    /// Returns `Some(TRACK NAME)` or `None` if no track name is present.
+    pub fn title(&self) -> Option<String> {
+        self.tag.title().and_then(|x| Some(x.to_string()))
+    }
 
-	/// Sets the track name.
-	pub fn set_title(&mut self, title: &str) {
-		self.tag.set_title(title)
-	}
+    /// Sets the track name.
+    pub fn set_title(&mut self, title: &str) {
+        self.tag.set_title(title)
+    }
 
-	/// Returns the artist name, or an empty string if no artist name is present.
-	pub fn artist(&self) -> Option<String> {
-		self.tag.artist().and_then(|x| Some(x.to_string()))
-	}
+    /// Returns `Some(ARTIST NAME)` or `None` if no artist name is present.
+    pub fn artist(&self) -> Option<String> {
+        self.tag.artist().and_then(|x| Some(x.to_string()))
+    }
 
-	/// Sets the artist name.
-	pub fn set_artist(&mut self, artist: &str) {
-		self.tag.set_artist(artist)
-	}
+    /// Sets the artist name.
+    pub fn set_artist(&mut self, artist: &str) {
+        self.tag.set_artist(artist)
+    }
 
-	/// Returns the album name, or an empty string if no album name is present.
-	pub fn album(&self) -> Option<String> {
-		self.tag.album().and_then(|x| Some(x.to_string()))
-	}
+    /// Returns `Some(ALBUM NAME)` or `None` if no album name is present.
+    pub fn album(&self) -> Option<String> {
+        self.tag.album().and_then(|x| Some(x.to_string()))
+    }
 
-	/// Sets the album name.
-	pub fn set_album(&mut self, album: &str) {
-		self.tag.set_album(album)
-	}
+    /// Sets the album name.
+    pub fn set_album(&mut self, album: &str) {
+        self.tag.set_album(album)
+    }
 
-	/// Returns the track comment, or an empty string if no track comment is
-	/// present.
-	pub fn comment(&self) -> Option<String> {
-		if let Some(frame) = self.tag.get("COMM") {
-			if let Some(comment) = frame.content().comment() {
-				return Some(comment.text.clone());
-			}
-		}
-		None
-	}
+    /// Returns `Some(TRACK COMMENT)` or `None` if no track comment is present.
+    pub fn comment(&self) -> Option<String> {
+        if let Some(frame) = self.tag.get("COMM") {
+            if let Some(comment) = frame.content().comment() {
+                return Some(comment.text.clone());
+            }
+        }
+        None
+    }
 
-	/// Returns the track number, or 0 if no track number is present.
-	pub fn track(&self) -> Option<u32> {
-		self.tag.track()
-	}
+    /// Returns `Some(TRACK NUMBER)` or `None` if track number is present.
+    pub fn track(&self) -> Option<u32> {
+        self.tag.track()
+    }
 
-	/// Sets the track number.
-	pub fn set_track(&mut self, track: u32) {
-		self.tag.set_track(track)
-	}
+    /// Sets the track number.
+    pub fn set_track(&mut self, track: u32) {
+        self.tag.set_track(track)
+    }
 }

--- a/src/taglib.rs
+++ b/src/taglib.rs
@@ -1,0 +1,91 @@
+use std::path::PathBuf;
+
+/// A representation of an audio file, with meta-data and properties.
+pub struct File {
+	path: PathBuf,
+}
+
+impl File {
+	/// Creates a new `taglib::File` for the given `path`.
+	pub fn new(path: &PathBuf) -> Result<File, FileError> {
+		Ok(File {
+			path: path.clone()
+		})
+	}
+
+	/// Returns the `taglib::Tag` instance for the given file.
+	pub fn tag(&self) -> Result<Tag, FileError> {
+		Ok(Tag {
+			path: &self.path,
+		})
+	}
+
+	/// Updates the meta-data of the file.
+	pub fn save(&self) -> bool {
+		true
+	}
+}
+
+#[derive(Debug)]
+pub enum FileError {
+	/// The file is an invalid or an unrecognized audio container
+	InvalidFile,
+	/// The file name is invalid
+	InvalidFileName,
+	/// No meta-data is available
+	NoAvailableTag,
+	/// No audio properties are available
+	NoAvailableAudioProperties,
+}
+
+/// The abstract meta-data container for audio files
+///
+/// Each `Tag` instance can only be created by the `taglib::File::tag()`
+/// method.
+#[allow(dead_code)]
+pub struct Tag<'a> {
+	path: &'a PathBuf,
+}
+
+impl Tag<'_> {
+	/// Returns the track name, or an empty string if no track name is present.
+	pub fn title(&self) -> Option<String> {
+		Some(format!("Title of '{:?}'", self.path))
+	}
+
+	/// Sets the track name.
+	pub fn set_title(&mut self, title: &str) {}
+
+	/// Returns the artist name, or an empty string if no artist name is present.
+	pub fn artist(&self) -> Option<String> {
+		Some(format!("Artist of '{:?}'", self.path))
+	}
+
+	/// Sets the artist name.
+	pub fn set_artist(&mut self, artist: &str) {}
+
+	/// Returns the album name, or an empty string if no album name is present.
+	pub fn album(&self) -> Option<String> {
+		Some(format!("Album of '{:?}'", self.path))
+	}
+
+	/// Sets the album name.
+	pub fn set_album(&mut self, album: &str) {}
+
+	/// Returns the track comment, or an empty string if no track comment is
+	/// present.
+	pub fn comment(&self) -> Option<String> {
+		Some(format!("Comment of '{:?}'", self.path))
+	}
+
+	/// Sets the track comment.
+	pub fn set_comment(&mut self, comment: &str) {}
+
+	/// Returns the track number, or 0 if no track number is present.
+	pub fn track(&self) -> Option<u32> {
+		Some(2)
+	}
+
+	/// Sets the track number.
+	pub fn set_track(&mut self, track: u32) {}
+}

--- a/src/taglib.rs
+++ b/src/taglib.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use id3::{self, TagLike};
+
 /// A representation of an audio file, with meta-data and properties.
 pub struct File {
 	path: PathBuf,
@@ -8,16 +10,16 @@ pub struct File {
 impl File {
 	/// Creates a new `taglib::File` for the given `path`.
 	pub fn new(path: &PathBuf) -> Result<File, FileError> {
-		Ok(File {
-			path: path.clone()
-		})
+		Ok(File { path: path.clone() })
 	}
 
 	/// Returns the `taglib::Tag` instance for the given file.
 	pub fn tag(&self) -> Result<Tag, FileError> {
-		Ok(Tag {
-			path: &self.path,
-		})
+		if let Ok(tag) = id3::Tag::read_from_path(&self.path) {
+			Ok(Tag { tag })
+		} else {
+			Err(FileError::NoAvailableTag)
+		}
 	}
 
 	/// Updates the meta-data of the file.
@@ -43,49 +45,57 @@ pub enum FileError {
 /// Each `Tag` instance can only be created by the `taglib::File::tag()`
 /// method.
 #[allow(dead_code)]
-pub struct Tag<'a> {
-	path: &'a PathBuf,
+pub struct Tag {
+	tag: id3::Tag,
 }
 
-impl Tag<'_> {
+impl Tag {
 	/// Returns the track name, or an empty string if no track name is present.
 	pub fn title(&self) -> Option<String> {
-		Some(format!("Title of '{:?}'", self.path))
+		self.tag.title().and_then(|x| Some(x.to_string()))
 	}
 
 	/// Sets the track name.
-	pub fn set_title(&mut self, title: &str) {}
+	pub fn set_title(&mut self, title: &str) {
+		self.tag.set_title(title)
+	}
 
 	/// Returns the artist name, or an empty string if no artist name is present.
 	pub fn artist(&self) -> Option<String> {
-		Some(format!("Artist of '{:?}'", self.path))
+		self.tag.artist().and_then(|x| Some(x.to_string()))
 	}
 
 	/// Sets the artist name.
-	pub fn set_artist(&mut self, artist: &str) {}
+	pub fn set_artist(&mut self, artist: &str) {
+		self.tag.set_artist(artist)
+	}
 
 	/// Returns the album name, or an empty string if no album name is present.
 	pub fn album(&self) -> Option<String> {
-		Some(format!("Album of '{:?}'", self.path))
+		self.tag.album().and_then(|x| Some(x.to_string()))
 	}
 
 	/// Sets the album name.
-	pub fn set_album(&mut self, album: &str) {}
+	pub fn set_album(&mut self, album: &str) {
+		self.tag.set_album(album)
+	}
 
 	/// Returns the track comment, or an empty string if no track comment is
 	/// present.
 	pub fn comment(&self) -> Option<String> {
-		Some(format!("Comment of '{:?}'", self.path))
+		None // TODO: Look into joining the comments iterator
 	}
 
 	/// Sets the track comment.
-	pub fn set_comment(&mut self, comment: &str) {}
+	pub fn set_comment(&mut self, comment: &str) {} // TODO
 
 	/// Returns the track number, or 0 if no track number is present.
 	pub fn track(&self) -> Option<u32> {
-		Some(2)
+		self.tag.track()
 	}
 
 	/// Sets the track number.
-	pub fn set_track(&mut self, track: u32) {}
+	pub fn set_track(&mut self, track: u32) {
+		self.tag.set_track(track)
+	}
 }

--- a/src/taglib.rs
+++ b/src/taglib.rs
@@ -83,11 +83,13 @@ impl Tag {
 	/// Returns the track comment, or an empty string if no track comment is
 	/// present.
 	pub fn comment(&self) -> Option<String> {
-		None // TODO: Look into joining the comments iterator
+		if let Some(frame) = self.tag.get("COMM") {
+			if let Some(comment) = frame.content().comment() {
+				return Some(comment.text.clone());
+			}
+		}
+		None
 	}
-
-	/// Sets the track comment.
-	pub fn set_comment(&mut self, comment: &str) {} // TODO
 
 	/// Returns the track number, or 0 if no track number is present.
 	pub fn track(&self) -> Option<u32> {


### PR DESCRIPTION
Replace taglib (which contains a lot of unsafe code and causes seg faults on my machine) with id3.